### PR TITLE
Add/pawsey configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ all_results/
 work/
 NOTES
 guides/
+.vscode/

--- a/config/nimbus.config
+++ b/config/nimbus.config
@@ -1,0 +1,43 @@
+/// profile for the Nimbus cloud at Pawsey
+
+/// Set default parameters
+// Any parameters provided by the user with a -params-file or 
+// with --param (i.e. --outDir) command-line arguments will 
+// override the values defined here
+  params {
+    help     = false
+    version  = '1.1'
+    outDir   = './all_results'
+    input    = false
+
+// Nimbus specific parameters
+    cluster = 'nimbus'
+    work_dir = '/data/work'
+  }
+
+workDir = ${params.work_dir}
+process.cache = 'lenient'
+
+
+docker {
+  enabled = true
+  runOptions = '-u $(id -u):$(id -g) -v ${params.work_dir}:${params.work_dir}'
+}
+
+/// Name containers to be used for each module
+// container__samtools = "quay.io/biocontainers/samtools:1.14--hb421002_0"
+
+
+process {
+/// Resource allocation for various processes
+// Here you can be provide CPU and memory for all or various processes
+// Defining it as a parameter means users can customise/override when running the command.
+// you'll need to include this parameter in your process. See process1.nf for example.
+  cpus = 1 
+
+/// To specify resources for a specific process, use the following: 
+//  withName: 'samtools' {
+//    cpus    = N 
+//    memory  = 8.GB 
+//  }
+}

--- a/config/setonix.config
+++ b/config/setonix.config
@@ -1,0 +1,61 @@
+/// profile for the Setonix supercomputer at Pawsey
+
+/// Set default parameters
+// Any parameters provided by the user with a -params-file or 
+// with --param (i.e. --outDir) command-line arguments will 
+// override the values defined here
+  params {
+    help     = false
+    version  = '1.1'
+    outDir   = './all_results'
+    input    = false
+
+// Setonix specific parameters
+    cluster = 'setonix'
+    slurm_account = 'pawseyXXXX'
+    work_dir = "$MYSCRATCH/nxf_work"
+    cache_dir = "$MYSOFTWARE/.nextflow_singularity"
+  }
+
+workDir = ${params.work_dir}
+process {
+  cache = 'lenient'
+  stageInMode = 'symlink'
+}
+
+
+singularity {
+  enabled = true
+  envWhitelist = 'SINGULARITY_BINDPATH, SINGULARITYENV_LD_LIBRARY_PATH, SINGULARITYENV_LD_PRELOAD'
+  cacheDir = ${params.cache_dir}
+}
+
+/// Name containers to be used for each module
+// container__samtools = "quay.io/biocontainers/samtools:1.14--hb421002_0"
+
+
+process {
+  executor = 'slurm'
+  clusterOptions = "--account=${params.slurm_account}"
+  queue = 'work'
+
+/// Resource allocation for various processes
+// Here you can be provide CPU and memory for all or various processes
+// Defining it as a parameter means users can customise/override when running the command.
+// you'll need to include this parameter in your process. See process1.nf for example.
+  cpus = 1
+  time = '1h'
+  memory = '1800MB'
+    
+/// To specify resources for a specific process, use the following:
+//  withName: 'samtools' {
+//    cpus = 64
+//    time = '1d'
+//    memory = '120GB'
+//  }
+}
+executor {
+  $slurm {
+    queueSize = 1024
+  }
+}

--- a/config/standard.config
+++ b/config/standard.config
@@ -1,0 +1,38 @@
+/// standard (default) profile
+
+/// Set default parameters
+// Any parameters provided by the user with a -params-file or 
+// with --param (i.e. --outDir) command-line arguments will 
+// override the values defined here
+  params {
+    help     = false
+    version  = '1.1'
+    outDir   = './all_results'
+    input    = false
+  }
+
+
+/// Preset use of containers with Singularity
+  singularity {
+        enabled         = true
+        autoMounts      = true
+        temp            = '~/containers'
+        }
+
+/// Name containers to be used for each module
+// container__samtools = "quay.io/biocontainers/samtools:1.14--hb421002_0"
+
+
+process {
+/// Resource allocation for various processes
+// Here you can be provide CPU and memory for all or various processes
+// Defining it as a parameter means users can customise/override when running the command.
+// you'll need to include this parameter in your process. See process1.nf for example.
+  cpus = 1 
+
+/// To specify resources for a specific process, use the following: 
+//  withName: 'samtools' {
+//    cpus    = N 
+//    memory  = 8.GB 
+//  }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,69 +5,42 @@ manifest {
   homePage = 'https://github.com/Sydney-Informatics-Hub/Nextflow_DSL2_template'
 
 /// Mandate a minimum version of nextflow required to run the pipeline
-nextflowVersion = '!>=20.07.1'
+  nextflowVersion = '!>=20.07.1'
 }
 
 /// resume pipeline from last successful process
 resume = true 
 
+// Fail a task if any command returns non-zero exit code
+shell = ['/bin/bash', '-euo', 'pipefail']
+
+// Produce a workflow diagram  
+dag {
+  enabled = true
+  file = 'runInfo/dag.svg'
+}
+
+report {
+  enabled = true
+  file = 'runInfo/report.html'
+}
+
+timeline {
+  enabled = true
+  file = 'runInfo/timeline.html'
+}
+
+trace {
+  enabled = true
+  file = 'runInfo/trace.txt'
+}
+
 /// Enable various profiles depending on compute infrastructure to be run on
 // For more info: https://www.nextflow.io/docs/latest/config.html#config-profiles
 // Example from https://github.com/marcodelapierre/trinity-nf/blob/master/nextflow.config
 profiles {
+  standard    { includeConfig "config/standard.config" }
+  
+  setonix     { includeConfig "config/setonix.config" }
+  nimbus      { includeConfig "config/nimbus.config" }
 }
-
-/// Preset use of containers with Singularity
-  singularity {
-        enabled         = true
-        autoMounts      = true
-        temp            = '~/containers'
-        }
-
-/// Set default parameters
-// Any parameters provided by the user with a -params-file or 
-// with --param (i.e. --outDir) command-line arguments will 
-// override the values defined here
-  params.help     = false
-  params.version  = '1.1'
-  params.outDir   = './all_results'
-  params.input    = false
-
-/// Name containers to be used for each module
-// container__samtools = "quay.io/biocontainers/samtools:1.14--hb421002_0"
-
-/// Resource allocation for various processes
-// Here you can be provide CPU and memory for all or various processes
-// Defining it as a parameter means users can customise/override when running the command.
-// you'll need to include this parameter in your process. See process1.nf for example.
-  params.cpus = 1 
-
-/// To specify resources for a specific process, use the following: 
-//withName: 'samtools' {
-//    cpus    = N 
-//    memory  = 8.GB 
-//}
-
-// Fail a task if any command returns non-zero exit code
-  shell = ['/bin/bash', '-euo', 'pipefail']
-
-// Produce a workflow diagram  
-  dag {
-    enabled = true
-    file = 'runInfo/dag.svg'
-  }
-
-  report {
-    enabled = true
-    file = 'runInfo/report.html'
-  }
-
-  timeline {
-    enabled = true
-    file = 'runInfo/timeline.html'
-  }
-
-  trace {
-    enabled = true
-    file = 'runInfo/trace.txt'
-  }


### PR DESCRIPTION
I have slightly changed the structure of `nextflow.config`, to modularise various `profiles` in distinct files under `config/`.
Right now there are the following profiles:
* `standard`
* `setonix`
* `nimbus`

Note that when using profiles, a single scope (e.g. `params`, or `process`) should NOT appear both outside and inside the profile, otherwise configs will not be parsed correctly (see warning in https://nextflow.io/docs/latest/config.html#config-profiles).
If it gets tedious to repeat e.g. the container names in all profiles, I think it is possible to have them in one file, that is then `includeConfig`ed in all profile files.
